### PR TITLE
doc:use `Buffer.byteLength` for  Content-Length

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -859,7 +859,7 @@ Example:
 ```js
 var body = 'hello world';
 response.writeHead(200, {
-  'Content-Length': body.length,
+  'Content-Length': Buffer.byteLength(body),
   'Content-Type': 'text/plain' });
 ```
 
@@ -1181,7 +1181,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',
-    'Content-Length': postData.length
+    'Content-Length': Buffer.byteLength(postData)
   }
 };
 


### PR DESCRIPTION
As the description in http.md:

> If the body contains higher coded characters then Buffer.byteLength() should be used to determine the number of bytes in a given encoding.
